### PR TITLE
Feature/hcms 9/open space

### DIFF
--- a/backend/blogging/package.json
+++ b/backend/blogging/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "tsc": "tsc",
     "dev": "nodemon -e js,ts src/app.ts",
-    "test": "mocha -r ts-node/register --ui tdd test/domain/**/*.ts",
+    "test": "mocha -r ts-node/register --ui tdd test/**/*.ts",
     "prestart": "tsc",
     "start": "node ./dist/app.js"
   },

--- a/backend/blogging/package.json
+++ b/backend/blogging/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "tsc": "tsc",
     "dev": "nodemon -e js,ts src/app.ts",
-    "test": "mocha -r ts-node/register test/**/*.ts",
+    "test": "mocha -r ts-node/register --ui tdd test/domain/**/*.ts",
     "prestart": "tsc",
     "start": "node ./dist/app.js"
   },

--- a/backend/blogging/src/domain/commands/OpenSpaceCommand.ts
+++ b/backend/blogging/src/domain/commands/OpenSpaceCommand.ts
@@ -1,5 +1,5 @@
 class OpenSpaceCommand {
-    constructor(readonly name: string) {
+    constructor(readonly name: string, readonly userId: string) {
     }
 }
 

--- a/backend/blogging/src/domain/entities/Space.ts
+++ b/backend/blogging/src/domain/entities/Space.ts
@@ -4,7 +4,7 @@ import EmptyUserIdException from "../exceptions/EmptyUserIdException";
 
 class Space {
     constructor(readonly id: string, readonly userId: string, readonly name: string) {
-        if (name.trim() === '') {
+        if (!name || name.trim() === '') {
             throw new EmptySpaceNameException();
         }
 
@@ -12,7 +12,7 @@ class Space {
             throw new MoreThan50CharactersSpaceNameException();
         }
 
-        if (userId.trim() === '') {
+        if (!userId || userId.trim() === '') {
             throw new EmptyUserIdException();
         }
     }

--- a/backend/blogging/src/domain/entities/Space.ts
+++ b/backend/blogging/src/domain/entities/Space.ts
@@ -1,14 +1,19 @@
 import EmptySpaceNameException from "../exceptions/EmptySpaceNameException";
 import MoreThan50CharactersSpaceNameException from "../exceptions/MoreThan50CharactersSpaceNameException";
+import EmptyUserIdException from "../exceptions/EmptyUserIdException";
 
 class Space {
-    constructor(readonly id: string, readonly name: string) {
+    constructor(readonly id: string, readonly userId: string, readonly name: string) {
         if (name.trim() === '') {
             throw new EmptySpaceNameException();
         }
 
         if (name.trim().length > 50) {
             throw new MoreThan50CharactersSpaceNameException();
+        }
+
+        if (userId.trim() === '') {
+            throw new EmptyUserIdException();
         }
     }
 }

--- a/backend/blogging/src/domain/exceptions/EmptyUserIdException.ts
+++ b/backend/blogging/src/domain/exceptions/EmptyUserIdException.ts
@@ -1,0 +1,12 @@
+class EmptyUserIdException extends Error {
+
+    constructor() {
+        super('a user id can not be empty');
+
+        this.name = 'EmptyUserIdException';
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+
+}
+
+export default EmptyUserIdException;

--- a/backend/blogging/src/domain/repositories/SpaceRepository.ts
+++ b/backend/blogging/src/domain/repositories/SpaceRepository.ts
@@ -4,9 +4,9 @@ import Criteria from "./criterias/Criteria";
 interface SpaceRepository {
     save(space: Space): void;
 
-    findBy(id: string): Space | undefined;
+    findBy(id: string): Promise<Space | undefined>;
 
-    query(query: Criteria<any>): Space[];
+    query(query: Criteria<any>): Promise<Space[]>;
 }
 
 export default SpaceRepository;

--- a/backend/blogging/src/domain/repositories/criterias/FindByNameCriteria.ts
+++ b/backend/blogging/src/domain/repositories/criterias/FindByNameCriteria.ts
@@ -1,12 +1,15 @@
 import Criteria from "./Criteria";
 
-class FindByNameCriteria implements Criteria<{ name: string }> {
+class FindByNameCriteria implements Criteria<{ name: string, userId: string }> {
 
-    constructor(private object: { name: string }) {
+    constructor(private object: { name: string, userId: string }) {
     }
 
-    matches(other: { name: string }): boolean {
-        return this.object.name === other.name;
+    matches(other: { name: string, userId: string }): boolean {
+        const isEqualName = this.object.name === other.name;
+        const isEqualUserId = this.object.userId === other.userId;
+
+        return isEqualName && isEqualUserId;
     }
 
 }

--- a/backend/blogging/src/domain/usecases/OpenSpaceUseCase.ts
+++ b/backend/blogging/src/domain/usecases/OpenSpaceUseCase.ts
@@ -12,9 +12,9 @@ class OpenSpaceUseCase {
                 private idGenerator: IdGenerator) {
     }
 
-    execute(command: OpenSpaceCommand): OpenedSpaceEvent {
+    async execute(command: OpenSpaceCommand): Promise<OpenedSpaceEvent> {
         const space = new Space(this.idGenerator.generate(), command.userId, command.name);
-        const spacesWithEqualName = this.repository.query(new FindByNameCriteria(space));
+        const spacesWithEqualName = await this.repository.query(new FindByNameCriteria(space));
 
         if (spacesWithEqualName.length > 0) {
             throw new NotUniqueSpaceNameException();

--- a/backend/blogging/src/domain/usecases/OpenSpaceUseCase.ts
+++ b/backend/blogging/src/domain/usecases/OpenSpaceUseCase.ts
@@ -13,7 +13,7 @@ class OpenSpaceUseCase {
     }
 
     execute(command: OpenSpaceCommand): OpenedSpaceEvent {
-        const space = new Space(this.idGenerator.generate(), command.name);
+        const space = new Space(this.idGenerator.generate(), command.userId, command.name);
         const spacesWithEqualName = this.repository.query(new FindByNameCriteria(space));
 
         if (spacesWithEqualName.length > 0) {

--- a/backend/blogging/src/infastructure/controller/RepositoryController.ts
+++ b/backend/blogging/src/infastructure/controller/RepositoryController.ts
@@ -1,6 +1,10 @@
 import express from 'express';
 import OpenSpaceUseCase from "../../domain/usecases/OpenSpaceUseCase";
 import OpenSpaceCommand from "../../domain/commands/OpenSpaceCommand";
+import EmptyUserIdException from "../../domain/exceptions/EmptyUserIdException";
+import EmptySpaceNameException from "../../domain/exceptions/EmptySpaceNameException";
+import MoreThan50CharactersSpaceNameException from "../../domain/exceptions/MoreThan50CharactersSpaceNameException";
+import NotUniqueSpaceNameException from "../../domain/exceptions/NotUniqueSpaceNameException";
 
 class SpaceController {
     constructor(private openSpaceUseCase: OpenSpaceUseCase) {
@@ -14,9 +18,48 @@ class SpaceController {
             const userId = req.body.userid;
 
             const command = new OpenSpaceCommand(name, userId);
-            const openedSpaceEvent = this.openSpaceUseCase.execute(command);
 
-            res.send(openedSpaceEvent);
+            try {
+                const openedSpaceEvent = this.openSpaceUseCase.execute(command);
+                res.send(openedSpaceEvent);
+            } catch (e) {
+                let message;
+
+                if (e instanceof EmptyUserIdException) {
+                    message = {
+                        field: 'userid',
+                        value: userId || '',
+                        cause: 'userid can not be empty or made of whitespace'
+                    }
+                }
+
+                if (e instanceof EmptySpaceNameException) {
+                    message = {
+                        field: 'name',
+                        value: name || '',
+                        cause: 'name can not be empty or made of whitespace'
+                    }
+                }
+
+                if (e instanceof MoreThan50CharactersSpaceNameException) {
+                    message = {
+                        field: 'name',
+                        value: name || '',
+                        cause: 'name can not contain more than 50 characters'
+                    }
+                }
+
+                if (e instanceof NotUniqueSpaceNameException) {
+                    message = {
+                        field: 'name',
+                        value: name || '',
+                        cause: 'it already exists a space with an equal name'
+                    }
+                }
+
+                res.status(400).send(message);
+            }
+
         });
 
         return router;

--- a/backend/blogging/src/infastructure/controller/RepositoryController.ts
+++ b/backend/blogging/src/infastructure/controller/RepositoryController.ts
@@ -11,8 +11,9 @@ class SpaceController {
 
         router.post('/', (req, res) => {
             const name = req.body.name;
+            const userId = req.body.userid;
 
-            const command = new OpenSpaceCommand(name);
+            const command = new OpenSpaceCommand(name, userId);
             const openedSpaceEvent = this.openSpaceUseCase.execute(command);
 
             res.send(openedSpaceEvent);

--- a/backend/blogging/src/infastructure/controller/RepositoryController.ts
+++ b/backend/blogging/src/infastructure/controller/RepositoryController.ts
@@ -7,6 +7,8 @@ import MoreThan50CharactersSpaceNameException from "../../domain/exceptions/More
 import NotUniqueSpaceNameException from "../../domain/exceptions/NotUniqueSpaceNameException";
 
 class SpaceController {
+    private errorFactory = new ErrorMessageFactory();
+
     constructor(private openSpaceUseCase: OpenSpaceUseCase) {
     }
 
@@ -23,46 +25,55 @@ class SpaceController {
                 const openedSpaceEvent = this.openSpaceUseCase.execute(command);
                 res.send(openedSpaceEvent);
             } catch (e) {
-                let message;
-
-                if (e instanceof EmptyUserIdException) {
-                    message = {
-                        field: 'userid',
-                        value: userId || '',
-                        cause: 'userid can not be empty or made of whitespace'
-                    }
-                }
-
-                if (e instanceof EmptySpaceNameException) {
-                    message = {
-                        field: 'name',
-                        value: name || '',
-                        cause: 'name can not be empty or made of whitespace'
-                    }
-                }
-
-                if (e instanceof MoreThan50CharactersSpaceNameException) {
-                    message = {
-                        field: 'name',
-                        value: name || '',
-                        cause: 'name can not contain more than 50 characters'
-                    }
-                }
-
-                if (e instanceof NotUniqueSpaceNameException) {
-                    message = {
-                        field: 'name',
-                        value: name || '',
-                        cause: 'it already exists a space with an equal name'
-                    }
-                }
-
-                res.status(400).send(message);
+                let errorMessage = this.errorFactory.createFrom(e, command);
+                res.status(400).send(errorMessage);
             }
-
         });
 
         return router;
+    }
+}
+
+class ErrorMessageFactory {
+
+    createFrom(e: Error, command: OpenSpaceCommand): { field: string, value: string, cause: string } {
+        if (e instanceof EmptyUserIdException) {
+            return {
+                field: 'userid',
+                value: command.userId || '',
+                cause: 'userid can not be empty or made of whitespace'
+            }
+        }
+
+        if (e instanceof EmptySpaceNameException) {
+            return {
+                field: 'name',
+                value: command.name || '',
+                cause: 'name can not be empty or made of whitespace'
+            }
+        }
+
+        if (e instanceof MoreThan50CharactersSpaceNameException) {
+            return {
+                field: 'name',
+                value: command.name || '',
+                cause: 'name can not contain more than 50 characters'
+            }
+        }
+
+        if (e instanceof NotUniqueSpaceNameException) {
+            return {
+                field: 'name',
+                value: command.name || '',
+                cause: 'it already exists a space with an equal name'
+            }
+        }
+
+        return {
+            field: '',
+            value: '',
+            cause: 'unknown error'
+        }
     }
 }
 

--- a/backend/blogging/src/infastructure/repositories/InMemorySpaceRepository.ts
+++ b/backend/blogging/src/infastructure/repositories/InMemorySpaceRepository.ts
@@ -9,11 +9,11 @@ class InMemorySpaceRepository implements SpaceRepository {
         this.spaces.set(space.id, space);
     }
 
-    findBy(id: string): Space | undefined {
+    async findBy(id: string): Promise<Space | undefined> {
         return this.spaces.get(id);
     }
 
-    query(criteria: Criteria<any>): Space[] {
+    async query(criteria: Criteria<any>): Promise<Space[]> {
         const filtered = [];
 
         for (let space of this.spaces.values()) {

--- a/backend/blogging/src/shared/StaticIdGenerator.ts
+++ b/backend/blogging/src/shared/StaticIdGenerator.ts
@@ -5,7 +5,7 @@ class StaticIdGenerator implements IdGenerator {
     }
 
     generate(): string {
-        return '1';
+        return this.id;
     }
 }
 

--- a/backend/blogging/test/domain/repositories/criterias/FindByNameCriteriaTest.ts
+++ b/backend/blogging/test/domain/repositories/criterias/FindByNameCriteriaTest.ts
@@ -1,23 +1,50 @@
-import {expect} from 'chai';
+import {assert} from 'chai';
 import FindByNameCriteria from "../../../../src/domain/repositories/criterias/FindByNameCriteria";
 
-const testSubject = new FindByNameCriteria({name: 'a', userId: '1'});
-const objectWithSameName = {name: 'a', userId: '1'};
-const objectWithOtherName = {name: 'b', userId: '1'};
+const userId = '1';
+const otherUserId = '2';
+const equalId = userId;
+const name = 'a';
+const unequalName = 'b';
+const equalName = name;
+
+const testSubject = new FindByNameCriteria({name, userId});
 
 
-describe('FindByNameCriteria', () => {
-    describe('when match', () => {
-        it('with unequal name, it returns false', () => {
-            const isMatch = testSubject.matches(objectWithOtherName);
+suite('FindByNameCriteria', () => {
 
-            expect(isMatch).to.be.false;
+    suite('when verify', () => {
+        test('given unequal name, same user id -> it returns false', () => {
+            const obj = {name: unequalName, userId: equalId};
+
+            const isMatch = testSubject.matches(obj);
+
+            assert.isFalse(isMatch);
         });
 
-        it('with equal name, it returns true', () => {
-            const isMatch = testSubject.matches(objectWithSameName);
+        test('given unequal name, different user id -> it returns false', () => {
+            const obj = {name: unequalName, userId: otherUserId};
 
-            expect(isMatch).to.be.true;
+            const isMatch = testSubject.matches(obj);
+
+            assert.isFalse(isMatch);
         });
-    })
+
+        test('given equal name, different user id -> it returns false', () => {
+            const obj = {name: equalName, userId: otherUserId};
+
+            const isMatch = testSubject.matches(obj);
+
+            assert.isFalse(isMatch);
+        });
+
+        test('given equal name, same user id -> it returns true', () => {
+            const obj = {name: equalName, userId: equalId};
+
+            const isMatch = testSubject.matches(obj);
+
+            assert.isTrue(isMatch);
+        });
+    });
+
 });

--- a/backend/blogging/test/domain/repositories/criterias/FindByNameCriteriaTest.ts
+++ b/backend/blogging/test/domain/repositories/criterias/FindByNameCriteriaTest.ts
@@ -1,14 +1,13 @@
 import {expect} from 'chai';
 import FindByNameCriteria from "../../../../src/domain/repositories/criterias/FindByNameCriteria";
 
-const testSubject = new FindByNameCriteria({name: 'a'});
-const objectWithSameName = {name: 'a'};
-const objectWithOtherName = {name: 'b'};
+const testSubject = new FindByNameCriteria({name: 'a', userId: '1'});
+const objectWithSameName = {name: 'a', userId: '1'};
+const objectWithOtherName = {name: 'b', userId: '1'};
 
 
 describe('FindByNameCriteria', () => {
     describe('when match', () => {
-
         it('with unequal name, it returns false', () => {
             const isMatch = testSubject.matches(objectWithOtherName);
 

--- a/backend/blogging/test/domain/usecases/OpenSpaceUseCaseTest.ts
+++ b/backend/blogging/test/domain/usecases/OpenSpaceUseCaseTest.ts
@@ -24,15 +24,16 @@ const name = nameMadeOfOneCharacter;
 let testSubject: OpenSpaceUseCase;
 let repository: InMemorySpaceRepository;
 
-beforeEach(() => {
-    repository = new InMemorySpaceRepository();
-    testSubject = new OpenSpaceUseCase(repository, new StaticIdGenerator(spaceId));
-});
+suite('Open Space Use Case', () => {
 
-describe('Open Space', () => {
+    setup(() => {
+        repository = new InMemorySpaceRepository();
+        testSubject = new OpenSpaceUseCase(repository, new StaticIdGenerator(spaceId));
+    });
 
-    describe('when execute', () => {
-        it('with empty name it fails', () => {
+    suite('when execute', () => {
+
+        test('given empty name -> throws exception for an empty name', () => {
             let exception;
             const command = new OpenSpaceCommand(emptyName, userId);
 
@@ -45,7 +46,7 @@ describe('Open Space', () => {
             }
         });
 
-        it('with only whitespaces as name it fails', () => {
+        test('given whitespaces as name -> throws exception for an empty name', () => {
             let exception;
             const command = new OpenSpaceCommand(nameWithOnlyWhitespace, userId);
 
@@ -58,7 +59,7 @@ describe('Open Space', () => {
             }
         });
 
-        it('with more than 50 characters as name it fails', () => {
+        test('given more than 50 characters as name -> throws exception for more than 50 characters', () => {
             let exception;
             const command = new OpenSpaceCommand(nameMadeOf51Characters, userId);
 
@@ -71,7 +72,7 @@ describe('Open Space', () => {
             }
         });
 
-        it('with same name as a previous space it fails for the same user id', () => {
+        test('given same name, same user id -> throws exception for unique space names', () => {
             let exception;
             const previous = new OpenSpaceCommand(name, userId);
             const command = new OpenSpaceCommand(name, userId);
@@ -86,7 +87,7 @@ describe('Open Space', () => {
             }
         });
 
-        it('with an empty user id; it fails', () => {
+        test('given an empty user id -> throws exception for empty user id', () => {
             let exception;
             const command = new OpenSpaceCommand(name, emptyUserId);
 
@@ -99,7 +100,7 @@ describe('Open Space', () => {
             }
         });
 
-        it('with only whitespaces as user id; it fails', () => {
+        test('given only whitespaces as user id -> throws exception for empty user id', () => {
             let exception;
             const command = new OpenSpaceCommand(name, userIdWithOnlyWhitespace);
 
@@ -112,8 +113,8 @@ describe('Open Space', () => {
             }
         });
 
-        describe('with one character as name and a user id', () => {
-            it('it opens a space', () => {
+        suite('given one character and same user id', () => {
+            test('it returns an event', () => {
                 const command = new OpenSpaceCommand(nameMadeOfOneCharacter, userId);
 
                 const openedSpaceEvent = testSubject.execute(command);
@@ -122,7 +123,7 @@ describe('Open Space', () => {
                 expect(openedSpaceEvent).to.be.deep.equal(expected)
             });
 
-            it('it opens a space when other space of an other user has same name', () => {
+            test('it stores the space in the repository', () => {
                 const previous = new OpenSpaceCommand(nameMadeOfOneCharacter, otherUserId);
                 testSubject.execute(previous);
                 const command = new OpenSpaceCommand(nameMadeOfOneCharacter, userId);
@@ -133,7 +134,7 @@ describe('Open Space', () => {
                 expect(openedSpaceEvent).to.be.deep.equal(expected)
             });
 
-            it('it stores space in repositories', () => {
+            test('when other user opened a space with the same name -> it stores the space in the repository', () => {
                 const command = new OpenSpaceCommand(nameMadeOfOneCharacter, userId);
 
                 testSubject.execute(command);
@@ -143,8 +144,8 @@ describe('Open Space', () => {
             });
         });
 
-        describe('with 50 characters as name and a user id', () => {
-            it('it opens a space', () => {
+        suite('given 50 character and same user id', () => {
+            test('it returns an event', () => {
                 const command = new OpenSpaceCommand(nameMadeOf50Characters, userId);
 
                 const openedSpaceEvent = testSubject.execute(command);
@@ -153,7 +154,7 @@ describe('Open Space', () => {
                 expect(openedSpaceEvent).to.be.deep.equal(expected);
             });
 
-            it('it opens a space when other space of an other user has same name', () => {
+            test('it stores the space in the repository', () => {
                 const previous = new OpenSpaceCommand(nameMadeOf50Characters, otherUserId);
                 testSubject.execute(previous);
                 const command = new OpenSpaceCommand(nameMadeOf50Characters, userId);
@@ -164,7 +165,7 @@ describe('Open Space', () => {
                 expect(openedSpaceEvent).to.be.deep.equal(expected)
             });
 
-            it('it stores space in repositories', () => {
+            test('when other user opened a space with the same name -> it stores the space in the repository', () => () => {
                 const command = new OpenSpaceCommand(nameMadeOf50Characters, userId);
 
                 testSubject.execute(command);
@@ -173,7 +174,5 @@ describe('Open Space', () => {
                 expect(repository.findBy(spaceId)).to.be.deep.equal(expected);
             });
         });
-
     });
-
 });

--- a/backend/blogging/test/domain/usecases/OpenSpaceUseCaseTest.ts
+++ b/backend/blogging/test/domain/usecases/OpenSpaceUseCaseTest.ts
@@ -33,12 +33,12 @@ suite('Open Space Use Case', () => {
 
     suite('when execute', () => {
 
-        test('given empty name -> throws exception for an empty name', () => {
+        test('given empty name -> throws exception for an empty name', async () => {
             let exception;
             const command = new OpenSpaceCommand(emptyName, userId);
 
             try {
-                testSubject.execute(command)
+                await testSubject.execute(command)
             } catch (e) {
                 exception = e;
             } finally {
@@ -46,12 +46,12 @@ suite('Open Space Use Case', () => {
             }
         });
 
-        test('given whitespaces as name -> throws exception for an empty name', () => {
+        test('given whitespaces as name -> throws exception for an empty name', async () => {
             let exception;
             const command = new OpenSpaceCommand(nameWithOnlyWhitespace, userId);
 
             try {
-                testSubject.execute(command)
+                await testSubject.execute(command)
             } catch (e) {
                 exception = e;
             } finally {
@@ -59,12 +59,12 @@ suite('Open Space Use Case', () => {
             }
         });
 
-        test('given more than 50 characters as name -> throws exception for more than 50 characters', () => {
+        test('given more than 50 characters as name -> throws exception for more than 50 characters', async () => {
             let exception;
             const command = new OpenSpaceCommand(nameMadeOf51Characters, userId);
 
             try {
-                testSubject.execute(command)
+                await testSubject.execute(command)
             } catch (e) {
                 exception = e;
             } finally {
@@ -72,14 +72,14 @@ suite('Open Space Use Case', () => {
             }
         });
 
-        test('given same name, same user id -> throws exception for unique space names', () => {
+        test('given same name, same user id -> throws exception for unique space names', async () => {
             let exception;
             const previous = new OpenSpaceCommand(name, userId);
             const command = new OpenSpaceCommand(name, userId);
-            testSubject.execute(previous);
+            await testSubject.execute(previous);
 
             try {
-                testSubject.execute(command);
+                await testSubject.execute(command);
             } catch (e) {
                 exception = e;
             } finally {
@@ -87,12 +87,12 @@ suite('Open Space Use Case', () => {
             }
         });
 
-        test('given an empty user id -> throws exception for empty user id', () => {
+        test('given an empty user id -> throws exception for empty user id', async () => {
             let exception;
             const command = new OpenSpaceCommand(name, emptyUserId);
 
             try {
-                testSubject.execute(command)
+                await testSubject.execute(command)
             } catch (e) {
                 exception = e;
             } finally {
@@ -100,12 +100,12 @@ suite('Open Space Use Case', () => {
             }
         });
 
-        test('given only whitespaces as user id -> throws exception for empty user id', () => {
+        test('given only whitespaces as user id -> throws exception for empty user id', async () => {
             let exception;
             const command = new OpenSpaceCommand(name, userIdWithOnlyWhitespace);
 
             try {
-                testSubject.execute(command)
+                await testSubject.execute(command)
             } catch (e) {
                 exception = e;
             } finally {
@@ -114,64 +114,66 @@ suite('Open Space Use Case', () => {
         });
 
         suite('given one character and same user id', () => {
-            test('it returns an event', () => {
+            test('it returns an event', async () => {
                 const command = new OpenSpaceCommand(nameMadeOfOneCharacter, userId);
 
-                const openedSpaceEvent = testSubject.execute(command);
+                const openedSpaceEvent = await testSubject.execute(command);
 
                 const expected = new OpenedSpaceEvent(spaceId, nameMadeOfOneCharacter);
                 expect(openedSpaceEvent).to.be.deep.equal(expected)
             });
 
-            test('it stores the space in the repository', () => {
+            test('it stores the space in the repository', async () => {
                 const previous = new OpenSpaceCommand(nameMadeOfOneCharacter, otherUserId);
-                testSubject.execute(previous);
+                await testSubject.execute(previous);
                 const command = new OpenSpaceCommand(nameMadeOfOneCharacter, userId);
 
-                const openedSpaceEvent = testSubject.execute(command);
+                const openedSpaceEvent = await testSubject.execute(command);
 
                 const expected = new OpenedSpaceEvent(spaceId, nameMadeOfOneCharacter);
                 expect(openedSpaceEvent).to.be.deep.equal(expected)
             });
 
-            test('when other user opened a space with the same name -> it stores the space in the repository', () => {
+            test('when other user opened a space with the same name -> it stores the space in the repository', async () => {
                 const command = new OpenSpaceCommand(nameMadeOfOneCharacter, userId);
 
-                testSubject.execute(command);
+                await testSubject.execute(command);
 
                 const expected = new Space(spaceId, userId, nameMadeOfOneCharacter);
-                expect(repository.findBy(spaceId)).to.be.deep.equal(expected);
+                const openedSpace = await repository.findBy(spaceId);
+                expect(openedSpace).to.be.deep.equal(expected);
             });
         });
 
         suite('given 50 character and same user id', () => {
-            test('it returns an event', () => {
+            test('it returns an event', async () => {
                 const command = new OpenSpaceCommand(nameMadeOf50Characters, userId);
 
-                const openedSpaceEvent = testSubject.execute(command);
+                const openedSpaceEvent = await testSubject.execute(command);
 
                 const expected = new OpenedSpaceEvent(spaceId, nameMadeOf50Characters);
                 expect(openedSpaceEvent).to.be.deep.equal(expected);
             });
 
-            test('it stores the space in the repository', () => {
+            test('it stores the space in the repository', async () => {
                 const previous = new OpenSpaceCommand(nameMadeOf50Characters, otherUserId);
-                testSubject.execute(previous);
+                await testSubject.execute(previous);
                 const command = new OpenSpaceCommand(nameMadeOf50Characters, userId);
 
-                const openedSpaceEvent = testSubject.execute(command);
+                const openedSpaceEvent = await testSubject.execute(command);
 
                 const expected = new OpenedSpaceEvent(spaceId, nameMadeOf50Characters);
                 expect(openedSpaceEvent).to.be.deep.equal(expected)
             });
 
-            test('when other user opened a space with the same name -> it stores the space in the repository', () => () => {
+            test('when other user opened a space with the same name -> it stores the space in the repository', async () => {
                 const command = new OpenSpaceCommand(nameMadeOf50Characters, userId);
 
-                testSubject.execute(command);
+                await testSubject.execute(command);
 
                 const expected = new Space(spaceId, userId, nameMadeOf50Characters);
-                expect(repository.findBy(spaceId)).to.be.deep.equal(expected);
+                const openedSpace = await repository.findBy(spaceId);
+                expect(openedSpace).to.be.deep.equal(expected);
             });
         });
     });

--- a/backend/blogging/test/domain/usecases/OpenSpaceUseCaseTest.ts
+++ b/backend/blogging/test/domain/usecases/OpenSpaceUseCaseTest.ts
@@ -7,6 +7,7 @@ import MoreThan50CharactersSpaceNameException
     from "../../../src/domain/exceptions/MoreThan50CharactersSpaceNameException";
 import InMemorySpaceRepository from "../../../src/infastructure/repositories/InMemorySpaceRepository";
 import StaticIdGenerator from "../../../src/shared/StaticIdGenerator";
+import Space from "../../../src/domain/entities/Space";
 
 const userId = '1';
 const otherUserId = '5';
@@ -135,9 +136,10 @@ describe('Open Space', () => {
             it('it stores space in repositories', () => {
                 const command = new OpenSpaceCommand(nameMadeOfOneCharacter, userId);
 
-                const openedSpaceEvent = testSubject.execute(command);
+                testSubject.execute(command);
 
-                expect(repository.findBy(spaceId)).to.be.deep.equal(openedSpaceEvent, userId);
+                const expected = new Space(spaceId, userId, nameMadeOfOneCharacter);
+                expect(repository.findBy(spaceId)).to.be.deep.equal(expected);
             });
         });
 
@@ -158,16 +160,17 @@ describe('Open Space', () => {
 
                 const openedSpaceEvent = testSubject.execute(command);
 
-                const expected = new OpenedSpaceEvent(spaceId, nameMadeOfOneCharacter);
+                const expected = new OpenedSpaceEvent(spaceId, nameMadeOf50Characters);
                 expect(openedSpaceEvent).to.be.deep.equal(expected)
             });
 
             it('it stores space in repositories', () => {
                 const command = new OpenSpaceCommand(nameMadeOf50Characters, userId);
 
-                const openedSpaceEvent = testSubject.execute(command);
+                testSubject.execute(command);
 
-                expect(repository.findBy(spaceId)).to.be.deep.equal(openedSpaceEvent);
+                const expected = new Space(spaceId, userId, nameMadeOf50Characters);
+                expect(repository.findBy(spaceId)).to.be.deep.equal(expected);
             });
         });
 


### PR DESCRIPTION
# Improvements
- add a `userid` in `Space` to reference which space belongs to which user
- send a response code `400` with a corresponding error message if the `OpenSpaceUsecase` throws an exception
- `OpenSpaceUsecase` and `SpaceRepository` are now asynchronous

# Changes
- switch the test style of the testing library "mocha" from `bdd` to `tdd`