### PR TITLE
feature/HCMS-51/creation-date

### DIFF
--- a/backend/blogging/package-lock.json
+++ b/backend/blogging/package-lock.json
@@ -2531,6 +2531,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/backend/blogging/package.json
+++ b/backend/blogging/package.json
@@ -19,6 +19,7 @@
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "firebase-admin": "latest",
+    "moment": "^2.26.0",
     "uuid": "^8.0.0"
   },
   "devDependencies": {

--- a/backend/blogging/src/app.ts
+++ b/backend/blogging/src/app.ts
@@ -9,6 +9,7 @@ import CreatorRepositoryFactory from "./infastructure/repositories/CreatorReposi
 import EnvironmentFactory from "./infastructure/environment/EnvironmentFactory";
 import Environment from "./infastructure/environment/Environment";
 import ControllerFactory from "./infastructure/controller/ControllerFactory";
+import CurrentDateGenerator from "./shared/CurrentDateGenerator";
 
 
 const app = express();
@@ -18,7 +19,7 @@ const creatorRepositoryFactory = new CreatorRepositoryFactory();
 const environmentFactory = new EnvironmentFactory();
 const environment = environmentFactory.buildBy(process.env.NODE_ENV);
 const creatorRepository = creatorRepositoryFactory.buildBy(environment);
-const controllerFactory = new ControllerFactory(new GlobalUniqueIdGenerator(), creatorRepository, new TypeFactory());
+const controllerFactory = new ControllerFactory(new GlobalUniqueIdGenerator(), creatorRepository, new CurrentDateGenerator(), new TypeFactory());
 const spaceController = controllerFactory.buildForSpace();
 const schemaController = controllerFactory.buildForSchema();
 const contentController = controllerFactory.buildForContent();

--- a/backend/blogging/src/domain/commands/ContentCommand.ts
+++ b/backend/blogging/src/domain/commands/ContentCommand.ts
@@ -1,0 +1,10 @@
+abstract class ContentCommand {
+    protected constructor(private _dateFormat: string | undefined = "DD.MM.YY HH:mm") {
+    }
+
+    get dateFormat(): string {
+        return <string>this._dateFormat
+    }
+}
+
+export default ContentCommand;

--- a/backend/blogging/src/domain/commands/ListAllContentsCommand.ts
+++ b/backend/blogging/src/domain/commands/ListAllContentsCommand.ts
@@ -1,12 +1,9 @@
 import ContentCommand from "./ContentCommand";
 
-class ViewContentCommand extends ContentCommand {
+export class ListAllContentsCommand extends ContentCommand {
     constructor(public creatorId: string,
                 public spaceId: string,
-                public contentId: string,
                 dateFormat: string | undefined) {
         super(dateFormat)
     }
 }
-
-export default ViewContentCommand;

--- a/backend/blogging/src/domain/commands/WriteContentCommand.ts
+++ b/backend/blogging/src/domain/commands/WriteContentCommand.ts
@@ -1,9 +1,13 @@
-class WriteContentCommand {
+import ContentCommand from "./ContentCommand";
+
+class WriteContentCommand extends ContentCommand {
     constructor(public schemaId: string,
                 public creatorId: string,
                 public spaceId: string,
                 public contentName: string,
-                public content: { typeId: string; name: string, content: string }[]) {
+                public content: { typeId: string; name: string, content: string }[],
+                _dateFormat: string | undefined) {
+        super(_dateFormat)
     }
 }
 

--- a/backend/blogging/src/domain/entities/Content.ts
+++ b/backend/blogging/src/domain/entities/Content.ts
@@ -9,6 +9,7 @@ export class Content {
     constructor(readonly id: string,
                 readonly name: string,
                 private schema: Schema,
+                readonly creationDate: Date,
                 readonly typeMappings: TypeMappings) {
         if (schema.isNotFitInWith(typeMappings))
             throw new ContentNotFitInWithSchema();

--- a/backend/blogging/src/domain/events/ViewContentEvent.ts
+++ b/backend/blogging/src/domain/events/ViewContentEvent.ts
@@ -1,6 +1,7 @@
 class ViewContentEvent {
     constructor(readonly id: string,
                 readonly name: string,
+                readonly creationDate: Date,
                 readonly schema: { id: string, name: string },
                 readonly mapping: { type: { id: string, name: string }, content: string }[]) {
     }

--- a/backend/blogging/src/domain/events/WriteContentEvent.ts
+++ b/backend/blogging/src/domain/events/WriteContentEvent.ts
@@ -1,7 +1,7 @@
 export class WrittenContentEvent {
     constructor(readonly contentId: string,
                 readonly creatorId: string,
-                readonly contentDate: Date,
+                readonly creationDate: Date,
                 readonly content: { typeId: string; name: string, content: string }[]) {
 
     }

--- a/backend/blogging/src/domain/events/WriteContentEvent.ts
+++ b/backend/blogging/src/domain/events/WriteContentEvent.ts
@@ -1,5 +1,8 @@
 export class WrittenContentEvent {
-    constructor(readonly contentId: string, readonly creatorId: string, readonly content: { typeId: string; name: string, content: string }[]) {
+    constructor(readonly contentId: string,
+                readonly creatorId: string,
+                readonly contentDate: Date,
+                readonly content: { typeId: string; name: string, content: string }[]) {
 
     }
 

--- a/backend/blogging/src/domain/usecases/ListAllContentsUseCase.ts
+++ b/backend/blogging/src/domain/usecases/ListAllContentsUseCase.ts
@@ -24,7 +24,8 @@ class ListAllContentsUseCase {
     private map(contents: Content[]) {
         return contents.map(content => ({
             id: content.id,
-            name: content.name
+            name: content.name,
+            creationDate: content.creationDate
         }));
     }
 }
@@ -35,7 +36,7 @@ export class ListAllContentsCommand {
 }
 
 export class ListedAllContentsEvent {
-    constructor(readonly content: { id: string, name: string }[]) {
+    constructor(readonly content: { id: string, name: string, creationDate: Date }[]) {
     }
 }
 

--- a/backend/blogging/src/domain/usecases/ListAllContentsUseCase.ts
+++ b/backend/blogging/src/domain/usecases/ListAllContentsUseCase.ts
@@ -1,6 +1,7 @@
 import {CreatorRepository} from "../repositories/CreatorRepository";
 import {UnassignedIdException} from "../exceptions/UnassignedIdException";
 import Content from "../entities/Content";
+import {ListAllContentsCommand} from "../commands/ListAllContentsCommand";
 
 class ListAllContentsUseCase {
     constructor(private creatorRepository: CreatorRepository) {
@@ -27,11 +28,6 @@ class ListAllContentsUseCase {
             name: content.name,
             creationDate: content.creationDate
         }));
-    }
-}
-
-export class ListAllContentsCommand {
-    constructor(public creatorId: string, public spaceId: string) {
     }
 }
 

--- a/backend/blogging/src/domain/usecases/ViewContentUseCase.ts
+++ b/backend/blogging/src/domain/usecases/ViewContentUseCase.ts
@@ -26,6 +26,7 @@ class ViewContentUseCase {
         return {
             id: content.id,
             name: content.name,
+            creationDate: content.creationDate,
             schema: {
                 id: content.schemaId,
                 name: content.schemaName

--- a/backend/blogging/src/domain/usecases/WriteContentUseCase.ts
+++ b/backend/blogging/src/domain/usecases/WriteContentUseCase.ts
@@ -7,11 +7,13 @@ import Content from "../entities/Content";
 import {TypeMappings} from "../entities/Schema";
 import TypeFactory from "../factories/TypeFactory";
 import Space from "../entities/Space";
+import DateGenerator from "../../shared/DateGenerator";
 
 class WriteContentUseCase {
     constructor(private creatorRepository: CreatorRepository,
                 private idGenerator: IdGenerator,
-                private typeFactory: TypeFactory) {
+                private typeFactory: TypeFactory,
+                private dateGenerator: DateGenerator) {
     }
 
     async execute(command: WriteContentCommand): Promise<WrittenContentEvent> {
@@ -38,6 +40,7 @@ class WriteContentUseCase {
             this.idGenerator.generate(),
             command.contentName,
             creator.getSchemaBy(command.schemaId),
+            this.dateGenerator.generate(),
             new TypeMappings(typeMapping)
         );
 
@@ -48,6 +51,7 @@ class WriteContentUseCase {
         return new WrittenContentEvent(
             content.id,
             creator.id,
+            content.creationDate,
             command.content
         );
     }

--- a/backend/blogging/src/infastructure/builder/ContentControllerBuilder.ts
+++ b/backend/blogging/src/infastructure/builder/ContentControllerBuilder.ts
@@ -7,7 +7,12 @@ import ViewContentUseCase from "../../domain/usecases/ViewContentUseCase";
 class ContentControllerBuilder extends ControllerBuilder<ContentController> {
 
     build(): ContentController {
-        const writeContentUseCase = new WriteContentUseCase(this.creatorRepository, this.idGenerator, this.typeFactory);
+        const writeContentUseCase = new WriteContentUseCase(
+            this.creatorRepository,
+            this.idGenerator,
+            this.typeFactory,
+            this.dateGenerator
+        );
         const listAllContentsUseCase = new ListAllContentsUseCase(this.creatorRepository);
         const viewContentUseCase = new ViewContentUseCase(this.creatorRepository);
         return new ContentController(writeContentUseCase, listAllContentsUseCase, viewContentUseCase);

--- a/backend/blogging/src/infastructure/builder/ControllerBuilder.ts
+++ b/backend/blogging/src/infastructure/builder/ControllerBuilder.ts
@@ -1,11 +1,13 @@
 import {CreatorRepository} from "../../domain/repositories/CreatorRepository";
 import IdGenerator from "../../shared/IdGenerator";
 import TypeFactory from "../../domain/factories/TypeFactory";
+import DateGenerator from "../../shared/DateGenerator";
 
 abstract class ControllerBuilder<T> {
     protected creatorRepository!: CreatorRepository;
     protected idGenerator!: IdGenerator;
     protected typeFactory!: TypeFactory;
+    protected dateGenerator!: DateGenerator;
 
     withIdGenerator(idGenerator: IdGenerator): ControllerBuilder<T> {
         this.idGenerator = idGenerator;
@@ -19,6 +21,11 @@ abstract class ControllerBuilder<T> {
 
     withTypeFactory(typeFactory: TypeFactory): ControllerBuilder<T> {
         this.typeFactory = typeFactory;
+        return this;
+    }
+
+    public withDateGenerator(dateGenerator: DateGenerator): ControllerBuilder<T> {
+        this.dateGenerator = dateGenerator;
         return this;
     }
 

--- a/backend/blogging/src/infastructure/controller/ContentController.ts
+++ b/backend/blogging/src/infastructure/controller/ContentController.ts
@@ -3,9 +3,12 @@ import {DefineSchemaCommand} from "../../domain/commands/DefineSchemaCommand";
 import DefineSchemaUseCase from "../../domain/usecases/DefineSchemaUseCase";
 import WriteContentUseCase from "../../domain/usecases/WriteContentUseCase";
 import WriteContentCommand from "../../domain/commands/WriteContentCommand";
-import ListAllContentsUseCase, {ListAllContentsCommand} from "../../domain/usecases/ListAllContentsUseCase";
+import ListAllContentsUseCase from "../../domain/usecases/ListAllContentsUseCase";
 import ViewContentUseCase from "../../domain/usecases/ViewContentUseCase";
 import ViewContentCommand from "../../domain/commands/ViewContentCommand";
+import moment from "moment";
+import {WrittenContentEvent} from "../../domain/events/WriteContentEvent";
+import {ListAllContentsCommand} from "../../domain/commands/ListAllContentsCommand";
 
 class ContentController {
     constructor(private writeContentUseCase: WriteContentUseCase,
@@ -22,44 +25,73 @@ class ContentController {
                 req.body.creatorId,
                 req.params.spaceId,
                 req.body.name,
-                req.body.content
+                req.body.content,
+                <string | undefined>req.query.dateFormat,
             );
 
             try {
                 const writtenContentEvent = await this.writeContentUseCase.execute(command);
-                res.send(writtenContentEvent);
+                res.send({
+                    contentId: writtenContentEvent.contentId,
+                    creatorId: writtenContentEvent.creatorId,
+                    creationDate: this.format(writtenContentEvent.creationDate, command.dateFormat),
+                    content: writtenContentEvent.content
+                });
             } catch (e) {
                 res.status(400).send('post body is invalid');
             }
         });
 
         router.get('/spaces/:spaceId', async (req, res) => {
-            const command = new ListAllContentsCommand(req.get('creatorId') ?? "", req.params.spaceId);
+                const command = new ListAllContentsCommand(
+                    req.get('creatorId') ?? "",
+                    req.params.spaceId,
+                    <string | undefined>req.query.dateFormat);
 
-            try {
-                const writtenContentEvent = await this.listAllContentsUseCase.execute(command);
-                res.send(writtenContentEvent.content);
-            } catch (e) {
-                res.status(400).send('post body is invalid');
+                try {
+                    const writtenContentEvent = await this.listAllContentsUseCase.execute(command);
+
+                    const response = writtenContentEvent.content
+                                                        .map(({id, name, creationDate}) => ({
+                                                            id,
+                                                            name,
+                                                            creationDate: this.format(creationDate, command.dateFormat)
+                                                        }));
+                    res.send(response);
+                } catch (e) {
+                    res.status(400).send('post body is invalid');
+                }
             }
-        });
+        )
+        ;
 
         router.get('/:contentId/spaces/:spaceId', async (req, res) => {
             const command = new ViewContentCommand(
                 req.get('creatorId') ?? "",
                 req.params.spaceId,
-                req.params.contentId
+                req.params.contentId,
+                <string | undefined>req.query.dateFormat
             );
 
             try {
                 const viewedContentEvent = await this.viewContentUseCase.execute(command);
-                res.send(viewedContentEvent);
+                res.send({
+                    id: viewedContentEvent.id,
+                    name: viewedContentEvent.name,
+                    creationDate: this.format(viewedContentEvent.creationDate, command.dateFormat),
+                    schema: viewedContentEvent.schema,
+                    mapping: viewedContentEvent.mapping
+                });
             } catch (e) {
                 res.status(400).send('post body is invalid');
             }
         });
 
         return router;
+    }
+
+    private format(from: Date, to: string): string {
+        return moment(from).format(to)
     }
 }
 

--- a/backend/blogging/src/infastructure/controller/ControllerFactory.ts
+++ b/backend/blogging/src/infastructure/controller/ControllerFactory.ts
@@ -9,6 +9,7 @@ import SchemaControllerBuilder from "../builder/SchemaControllerBuilder";
 import ContentControllerBuilder from "../builder/ContentControllerBuilder";
 import CreatorController from "./CreatorController";
 import CreatorControllerBuilder from "../builder/CreatorControllerBuilder";
+import DateGenerator from "../../shared/DateGenerator";
 
 class ControllerFactory {
     private readonly spaceController: SpaceController;
@@ -18,6 +19,7 @@ class ControllerFactory {
 
     constructor(private idGenerator: IdGenerator,
                 private creatorRepository: CreatorRepository,
+                private dateGenerator: DateGenerator,
                 private typeFactory: TypeFactory) {
         this.spaceController = new SpaceControllerBuilder().withIdGenerator(idGenerator)
                                                            .withCreatorRepository(creatorRepository)
@@ -32,6 +34,7 @@ class ControllerFactory {
         this.contentController = new ContentControllerBuilder().withIdGenerator(idGenerator)
                                                                .withCreatorRepository(creatorRepository)
                                                                .withTypeFactory(typeFactory)
+                                                               .withDateGenerator(dateGenerator)
                                                                .build();
 
         this.creatorController = new CreatorControllerBuilder().withIdGenerator(idGenerator)

--- a/backend/blogging/src/shared/CurrentDateGenerator.ts
+++ b/backend/blogging/src/shared/CurrentDateGenerator.ts
@@ -1,0 +1,11 @@
+import DateGenerator from "./DateGenerator";
+
+class CurrentDateGenerator implements DateGenerator {
+
+    generate(): Date {
+        return new Date();
+    }
+
+}
+
+export default CurrentDateGenerator;

--- a/backend/blogging/src/shared/DateGenerator.ts
+++ b/backend/blogging/src/shared/DateGenerator.ts
@@ -1,0 +1,5 @@
+interface DateGenerator {
+    generate(): Date;
+}
+
+export default DateGenerator;

--- a/backend/blogging/src/shared/StaticDateGenerator.ts
+++ b/backend/blogging/src/shared/StaticDateGenerator.ts
@@ -1,0 +1,12 @@
+import DateGenerator from "./DateGenerator";
+
+class StaticDateGenerator implements DateGenerator {
+    constructor(private date: Date) {
+    }
+
+    generate(): Date {
+        return this.date;
+    }
+}
+
+export default StaticDateGenerator;

--- a/backend/blogging/test/domain/entities/CreatorTest.ts
+++ b/backend/blogging/test/domain/entities/CreatorTest.ts
@@ -96,7 +96,7 @@ suite('Creator Entity', () => {
             const creator = new Creator(creatorId, new Map(), new Map());
             creator.open(new Space('1', creator.id, 'name'));
             const undefinedSchema = new Schema('unit-test', 'podcast', new TypeDefinition([]));
-            const content = new Content('1', 'my first podcast', undefinedSchema, new TypeMappings([]));
+            const content = new Content('1', 'my first podcast', undefinedSchema, new Date(), new TypeMappings([]));
 
             try {
                 creator.write(content, space);
@@ -111,7 +111,7 @@ suite('Creator Entity', () => {
             const creator = new Creator(creatorId, new Map(), new Map());
             creator.define(schema);
             creator.open(new Space('1', creatorId, 'name'));
-            const content = new Content('1', 'my first podcast', schema, new TypeMappings([]));
+            const content = new Content('1', 'my first podcast', schema, new Date(), new TypeMappings([]));
             creator.write(content, space);
 
             const expected = creator.getContent(content.id, '1');

--- a/backend/blogging/test/domain/usecases/ListAllContentsUseCasesTest.ts
+++ b/backend/blogging/test/domain/usecases/ListAllContentsUseCasesTest.ts
@@ -1,5 +1,4 @@
 import ListAllContentsOfASpaceUseCase, {
-    ListAllContentsCommand,
     ListedAllContentsEvent
 } from "../../../src/domain/usecases/ListAllContentsUseCase";
 import InMemoryCreatorRepository from "../../../src/infastructure/repositories/InMemoryCreatorRepository";
@@ -9,6 +8,7 @@ import Creator from "../../../src/domain/entities/Creator";
 import Space from "../../../src/domain/entities/Space";
 import Content from "../../../src/domain/entities/Content";
 import Schema, {TypeDefinition, TypeMappings} from "../../../src/domain/entities/Schema";
+import {ListAllContentsCommand} from "../../../src/domain/commands/ListAllContentsCommand";
 
 suite('List All Content Use Cases', () => {
 

--- a/backend/blogging/test/domain/usecases/ListAllContentsUseCasesTest.ts
+++ b/backend/blogging/test/domain/usecases/ListAllContentsUseCasesTest.ts
@@ -62,11 +62,12 @@ suite('List All Content Use Cases', () => {
         });
 
         test('given an assigned creator id and spade id with content in this space -> returns an event with content', async () => {
+            const creationDate = new Date();
             const creator = new Creator('1', new Map(), new Map());
             const space = new Space('2', creator.id, 'My Podcast');
             const schema = new Schema('4', 'Podcast', new TypeDefinition([]));
             const typeMapping = new TypeMappings([]);
-            const content = new Content('3', 'my first podcast', schema, new Date(), typeMapping);
+            const content = new Content('3', 'my first podcast', schema, creationDate, typeMapping);
             space.add(content);
             creator.open(space);
             await creatorRepository.add(creator);
@@ -74,7 +75,7 @@ suite('List All Content Use Cases', () => {
 
             const event = await testSubject.execute(command);
 
-            assert.deepEqual(event, new ListedAllContentsEvent([{id: content.id, name: content.name}]));
+            assert.deepEqual(event, new ListedAllContentsEvent([{id: content.id, name: content.name, creationDate}]));
         });
     });
 

--- a/backend/blogging/test/domain/usecases/ListAllUseCasesTest.ts
+++ b/backend/blogging/test/domain/usecases/ListAllUseCasesTest.ts
@@ -66,7 +66,7 @@ suite('List All Content Use Cases', () => {
             const space = new Space('2', creator.id, 'My Podcast');
             const schema = new Schema('4', 'Podcast', new TypeDefinition([]));
             const typeMapping = new TypeMappings([]);
-            const content = new Content('3', 'my first podcast', schema, typeMapping);
+            const content = new Content('3', 'my first podcast', schema, new Date(), typeMapping);
             space.add(content);
             creator.open(space);
             await creatorRepository.add(creator);

--- a/backend/blogging/test/domain/usecases/ViewContentUseCaseTest.ts
+++ b/backend/blogging/test/domain/usecases/ViewContentUseCaseTest.ts
@@ -82,6 +82,7 @@ suite('View Content Use Case', () => {
                 new ViewContentEvent(
                     content.id,
                     content.name,
+                    content.creationDate,
                     {
                         id: schema.id,
                         name: schema.name

--- a/backend/blogging/test/domain/usecases/ViewContentUseCaseTest.ts
+++ b/backend/blogging/test/domain/usecases/ViewContentUseCaseTest.ts
@@ -68,7 +68,7 @@ suite('View Content Use Case', () => {
             const creator = new Creator('1', new Map(), new Map());
             const space = new Space('2', creator.id, 'My Podcast');
             const schema = new Schema('1', 'podcast', new TypeDefinition([]));
-            const content = new Content('3', 'my first podcast', schema, new TypeMappings([]));
+            const content = new Content('3', 'my first podcast', schema, new Date(), new TypeMappings([]));
             creator.open(space);
             creator.define(schema);
             creator.write(content, space);


### PR DESCRIPTION
A content is now saved with its creation date.

The creation date is displayed for the following use cases: 
 - Writing Content
 - Viewing content
 - List Contents

The format of the date can be specified by the query parameters `dateFormat`.

for example:

```
/contents/spaces/{{spaceId}}?dateFormat=DD.MM.YYYY HH:mm
```

The default value for `dateFormat` is `DD.MM.YYYY HH:mm` and therefore the following is equivalent to above:

```
/contents/spaces/{{spaceId}}
```