### PR TITLE
feature/HCMS-57/build-start-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# headless-cms
+# audity
+![CI](https://github.com/rgabisch/headless-cms/workflows/CI/badge.svg)
+## Description
+Audity is a headless-cms, which is specialized on the integration of audio files. It transcribes audio files and can be used for search engine optimization. 
+## Quick Start
+### Set up the Application
+```shell script
+git clone https://github.com/rgabisch/headless-cms.git
+cd headless-cms
+npm run install
+```
+
+### Run the Application
+The application is divided into frontend and backend and they are each started in a separate shell session.
+
+#### Frontend
+```shell script
+npm run start:frontend
+```
+
+#### Backend
+The backend can be started in different modes. In instance a decision can be made between the production and development mode
+
+```shell script
+npm run start:backend:dev
+# npm run start:backend:prod
+```

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -1,9 +1,6 @@
 import express from 'express';
 import bodyParser from 'body-parser'
 import GlobalUniqueIdGenerator from "./blogging/src/shared/GlobalUniqueIdGenerator";
-import InMemoryCreatorRepository from "./blogging/src/infastructure/repositories/InMemoryCreatorRepository";
-import Creator from "./blogging/src/domain/entities/Creator";
-import Schema, {TypeDefinition} from "./blogging/src/domain/entities/Schema";
 import TypeFactory from "./blogging/src/domain/factories/TypeFactory";
 import CreatorRepositoryFactory from "./blogging/src/infastructure/repositories/CreatorRepositoryFactory";
 import EnvironmentFactory from "./blogging/src/infastructure/environment/EnvironmentFactory";
@@ -16,7 +13,6 @@ import FireBaseUserRepository from "./identifying/src/infastructure/FireBaseUser
 import SignUpUseCase from "./identifying/src/domain/usecases/SignUpUseCase";
 import InMemoryUserRepository from "./identifying/src/infastructure/InMemoryUserRepository";
 import CreateCreatorUseCase from './blogging/src/domain/usecases/CreateCreatorUseCase';
-import {resolveSoa} from 'dns';
 
 
 const app = express();
@@ -39,10 +35,6 @@ const identifyingController = new IdentifyingController(new SignInUseCase(userRe
 
 
 if (process.env.NODE_ENV == Environment.DEV) {
-    // Create a new Creator
-    const one_creator = new Creator('1', new Map(), new Map());
-    (creatorRepository as InMemoryCreatorRepository).add(one_creator);
-
     signUpUseCase.execute({email: 'test@mail.de', pass: 'test'});
 }
 

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -41,21 +41,6 @@ const identifyingController = new IdentifyingController(new SignInUseCase(userRe
 if (process.env.NODE_ENV == Environment.DEV) {
     // Create a new Creator
     const one_creator = new Creator('1', new Map(), new Map());
-
-    // Create a new Type 'Number'
-    const typeFactory = new TypeFactory();
-    const type_number = typeFactory.createBy("Number");
-
-    // Create two Schemas
-    const type_1 = new TypeDefinition([{type: type_number, name: "Count"}]);
-    const type_2 = new TypeDefinition([{type: type_number, name: "Alter"}, {type: type_number, name: "Count"}]);
-    const one_schema = new Schema("2", "test_schema", type_1);
-    const second_schema = new Schema("3", "test_schema_2", type_2);
-
-    // Define the Schemas to the Creator
-    one_creator.define(one_schema);
-    one_creator.define(second_schema);
-
     (creatorRepository as InMemoryCreatorRepository).add(one_creator);
 
     signUpUseCase.execute({email: 'test@mail.de', pass: 'test'});

--- a/backend/blogging/src/domain/usecases/CreateCreatorUseCase.ts
+++ b/backend/blogging/src/domain/usecases/CreateCreatorUseCase.ts
@@ -11,13 +11,10 @@ class CreateCreatorUseCase {
 
     async execute(command: CreateCreatorCommand): Promise<CreateCreatorEvent> {
         const creator = await this.creatorRepository.findBy(command.id);
-        console.log('ba')
         if (creator)
             throw new AssignedIdException();
 
-        console.log('bb')
         await this.creatorRepository.add(new Creator(command.id, new Map(), new Map()));
-        console.log('bc')
 
         return new CreateCreatorEvent(command.id);
     }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "headless-cms",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "install:frontend": "cd frontend/audity && npm install",
+    "install:backend": "cd backend && npm install",
+    "install": "npm run install:frontend && npm run install:backend",
+    "test": "cd backend && npm run test",
+    "start:backend:watch": "cd backend && npm run start:watch",
+    "start:backend:dev": "cd backend && npm run start:dev",
+    "start:backend:prod": "cd backend && npm run start:prod",
+    "start:frontend": "cd frontend/audity && npm run serve"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rgabisch/headless-cms.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/rgabisch/headless-cms/issues"
+  },
+  "homepage": "https://github.com/rgabisch/headless-cms#readme"
+}


### PR DESCRIPTION
Scripts have been created in the root directory to simplify the use of the application.

It is no longer necessary to navigate to the subdirectories to start the application.

The application can now be started via:

```shell
npm run start:backend:dev
#npm run start:backend:prod
npm run start:frontend
```