### PR TITLE
Feature/HCMS-61/change-response-structure-of-schema

### DIFF
--- a/backend/blogging/src/domain/events/ListAllSchemasEvent.ts
+++ b/backend/blogging/src/domain/events/ListAllSchemasEvent.ts
@@ -1,8 +1,0 @@
-import Schema from '../entities/Schema'
-
-class ListAllSchemasEvent {
-    constructor(readonly schemas: Schema[]) {
-    }
-}
-
-export default ListAllSchemasEvent;

--- a/backend/blogging/src/domain/events/ListedAllSchemasEvent.ts
+++ b/backend/blogging/src/domain/events/ListedAllSchemasEvent.ts
@@ -1,0 +1,6 @@
+class ListedAllSchemasEvent {
+    constructor(readonly schemas: { id: string, name: string, types: { typeId: string, name: string }[] }[]) {
+    }
+}
+
+export default ListedAllSchemasEvent;

--- a/backend/blogging/src/domain/events/ViewSchemaEvent.ts
+++ b/backend/blogging/src/domain/events/ViewSchemaEvent.ts
@@ -1,9 +1,0 @@
-
-import Schema from '../entities/Schema';
-
-class ViewSchemaEvent {
-    constructor(readonly schema: Schema) {
-    }
-}
-
-export default ViewSchemaEvent;

--- a/backend/blogging/src/domain/events/ViewedSchemaEvent.ts
+++ b/backend/blogging/src/domain/events/ViewedSchemaEvent.ts
@@ -1,0 +1,8 @@
+class ViewedSchemaEvent {
+    constructor(readonly id: string,
+                readonly name: string,
+                readonly types: {typeId: string, name: string}[]) {
+    }
+}
+
+export default ViewedSchemaEvent;

--- a/backend/blogging/src/domain/usecases/ListAllSchemasUseCase.ts
+++ b/backend/blogging/src/domain/usecases/ListAllSchemasUseCase.ts
@@ -1,21 +1,40 @@
 import {CreatorRepository} from "../repositories/CreatorRepository";
 import ListAllSchemasCommand from "../commands/ListAllSchemasCommand";
-import ListAllSchemasEvent from "../events/ListAllSchemasEvent";
+import ListedAllSchemasEvent from "../events/ListedAllSchemasEvent";
 import {UnassignedIdException} from "../exceptions/UnassignedIdException";
 
-class ViewSchemaUseCase{
-    constructor(private creatorRepository: CreatorRepository){
+class ListAllSchemaUseCase {
+    constructor(private creatorRepository: CreatorRepository) {
     }
 
-    async execute(command: ListAllSchemasCommand): Promise<ListAllSchemasEvent>{
-        const creator = await this.creatorRepository.findBy(command.creatorId)
+    async execute(command: ListAllSchemasCommand): Promise<ListedAllSchemasEvent> {
+        const creator = await this.creatorRepository.findBy(command.creatorId);
 
         if (!creator)
             throw new UnassignedIdException();
 
-        const schemas = creator.getAllSchemas()
-        return new ListAllSchemasEvent(schemas)
+        const schemas = creator.getAllSchemas();
+
+        const mappedSchemas = [];
+        for (let schema of schemas) {
+
+            const mappedTypeDefinition = [];
+            for (let typeDefinition of schema.typeDefinition) {
+                mappedTypeDefinition.push({
+                    typeId: typeDefinition.type.id,
+                    name: typeDefinition.name
+                })
+            }
+
+            mappedSchemas.push({
+                id: schema.id,
+                name: schema.name,
+                types: mappedTypeDefinition
+            });
+        }
+
+        return new ListedAllSchemasEvent(mappedSchemas)
     }
 }
 
-export default ViewSchemaUseCase
+export default ListAllSchemaUseCase

--- a/backend/blogging/src/domain/usecases/ViewSchemaUseCase.ts
+++ b/backend/blogging/src/domain/usecases/ViewSchemaUseCase.ts
@@ -1,20 +1,33 @@
 import {CreatorRepository} from "../repositories/CreatorRepository";
 import ViewSchemaCommand from "../commands/ViewSchemaCommand";
-import ViewSchemaEvent from "../events/ViewSchemaEvent";
+import ViewedSchemaEvent from "../events/ViewedSchemaEvent";
 import {UnassignedIdException} from "../exceptions/UnassignedIdException";
 
-class ViewSchemaUseCase{
-    constructor(private creatorRepository: CreatorRepository){
+class ViewSchemaUseCase {
+    constructor(private creatorRepository: CreatorRepository) {
     }
 
-    async execute(command: ViewSchemaCommand): Promise<ViewSchemaEvent>{
-        const creator = await this.creatorRepository.findBy(command.creatorId)
+    async execute(command: ViewSchemaCommand): Promise<ViewedSchemaEvent> {
+        const creator = await this.creatorRepository.findBy(command.creatorId);
 
         if (!creator)
             throw new UnassignedIdException();
 
-        const schema = creator.getSchemaBy(command.schemaId)
-        return new ViewSchemaEvent(schema)
+        const schema = creator.getSchemaBy(command.schemaId);
+
+        const mappedTypeDefinition = [];
+        for (let typeDefinition of schema.typeDefinition) {
+            mappedTypeDefinition.push({
+                typeId: typeDefinition.type.id,
+                name: typeDefinition.name
+            })
+        }
+
+        return new ViewedSchemaEvent(
+            schema.id,
+            schema.name,
+            mappedTypeDefinition
+        );
     }
 }
 

--- a/backend/blogging/src/infastructure/controller/SchemaController.ts
+++ b/backend/blogging/src/infastructure/controller/SchemaController.ts
@@ -29,7 +29,7 @@ class SchemaController {
             const command = new ListAllSchemasCommand(<string>req.headers._creatorId);
             try {
                 const listAllSchemasEvent = await this.listAllSchemasUseCase.execute(command);
-                res.send(listAllSchemasEvent)
+                res.send(listAllSchemasEvent.schemas)
             } catch (e) {
                 res.status(404).send('404 - No Schema found');
             }


### PR DESCRIPTION
Simplified the response structure to view all or one single schema:

# List all schemas

```json
[
    {
        "id": "9c0534e0-b7d7-11ea-9793-d18a5d68150e",
        "name": "author",
        "types": []
    },
    {
        "id": "cd107180-b7d7-11ea-9793-d18a5d68150e",
        "name": "author",
        "types": [
            {
                "typeId": "1",
                "name": "Heading"
            }
        ]
    }
]
```

# View one Schema

```json
{
    "id": "cd107180-b7d7-11ea-9793-d18a5d68150e",
    "name": "author",
    "types": [
        {
            "typeId": "1",
            "name": "Heading"
        }
    ]
}
```